### PR TITLE
Modify drivers branch for Realtek 88x2bu chipsets

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -561,7 +561,7 @@ compilation_prepare()
 	if linux-version compare "${version}" ge 5.0 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
-		local rtl88x2buver="branch:fix-6.1"
+		local rtl88x2buver="branch:fix-v6.3"
 
 		display_alert "Adding" "Wireless drivers for Realtek 88x2bu chipsets ${rtl88x2buver}" "info"
 


### PR DESCRIPTION
Modify compilation-prepare.sh file:  Wireless drivers for Realtek 88x2bu chipsets: branch: fix-v6.3